### PR TITLE
Improve performance by memoizing to_string for Singles

### DIFF
--- a/Headers/array.h
+++ b/Headers/array.h
@@ -23,7 +23,7 @@ class Interaction
 {
     public:
         // used only in verbose mode, to have some id associated with the interaction
-        int id;
+        int id = -1;
 
         // the actual list of (factor, value) tuples
         std::vector<Single*> singles;
@@ -33,7 +33,7 @@ class Interaction
         std::set<int> rows;
 
         // easy lookup bool to cut down on redundant checks
-        bool is_covered;
+        bool is_covered = false;
 
         // this tracks all the T sets in which this interaction occurs; using this, one can obtain all the
         // relevant sets when a new row with this interaction is added
@@ -45,10 +45,9 @@ class Interaction
         std::map<T*, int64_t> deltas;
 
         // easy lookup bool to cut down on redundant checks
-        bool is_detectable;
+        bool is_detectable = false;
 
         std::string to_string();    // returns a string representing all Singles in the interaction
-        Interaction();  // default constructor, don't use this
         Interaction(std::vector<Single*> *temp);    // constructor with a premade vector of Single pointers
 };
 
@@ -79,10 +78,9 @@ class T
         std::set<T*> location_conflicts;
 
         // easy lookup bool to cut down on redundant checks
-        bool is_locatable;
+        bool is_locatable = false;
 
         std::string to_string();    // returns a string representing all Interactions in the set
-        T();    // default constructor, don't use this      
         T(std::vector<Interaction*> *temp); // constructor with a premade vector of Interaction pointers
 };
 

--- a/Headers/factor.h
+++ b/Headers/factor.h
@@ -29,28 +29,29 @@ Last updated 10/04/2022
 class Single
 {
     public:
-        uint64_t c_issues;  // in how many coverage issues does this Single appear
-        int64_t l_issues;   // in how many location issues does this Single appear
-        uint64_t d_issues;  // in how many detection issues does this Single appear
-        uint64_t factor;    // represents the factor, or column of the array
-        uint64_t value;     // represents the actual value of the factor
+        uint64_t c_issues = 0;  // in how many coverage issues does this Single appear
+        int64_t l_issues = 0;   // in how many location issues does this Single appear
+        uint64_t d_issues = 0;  // in how many detection issues does this Single appear
+        const uint64_t factor;    // represents the factor, or column of the array
+        const uint64_t value;     // represents the actual value of the factor
         std::set<int> rows;         // tracks the set of rows in which this (factor, value) occurs
-        std::string to_string();    // returns a string representing the (factor, value)
-        Single();                       // default constructor, don't use this
+        std::string to_string() const;    // returns a string representing the (factor, value)
+        const std::string str_rep;            // memoized to_string_internal
         Single(uint64_t f, uint64_t v); // constructor that takes the (factor, value)
+    private:
+        std::string to_string_internal() const;    // returns a string representing the (factor, value)
 };
 
 // think of this class as containing the information associated with a single column in the array
 class Factor
 {
     public:
-        uint64_t c_issues;  // total coverage issues of all associated Singles
-        int64_t l_issues;   // total location issues of all associated Singles
-        uint64_t d_issues;  // total detection issues of all associated Singles
-        uint64_t id;        // column number
-        uint64_t level;     // number of values the column can take on
-        Single **singles;   // pointer to array of Single pointers
-        Factor();                                           // default constructor, don't use this
+        uint64_t c_issues = 0;  // total coverage issues of all associated Singles
+        int64_t l_issues = 0;   // total location issues of all associated Singles
+        uint64_t d_issues = 0;  // total detection issues of all associated Singles
+        const uint64_t id = 0;        // column number
+        const uint64_t level = 0;     // number of values the column can take on
+        Single **singles = nullptr;   // pointer to array of Single pointers
         Factor(uint64_t i, uint64_t l, Single **ptr_array); // constructor that takes id, level, Single*
         ~Factor();
 };

--- a/Sources/array.cpp
+++ b/Sources/array.cpp
@@ -34,19 +34,9 @@ static void print_sets(std::vector<T*> sets);
 static void print_debug(Factor **factors, uint64_t num_factors);
 
 /* CONSTRUCTOR - initializes the object
- * - overloaded: this is the default with no parameters, and should not be used
-*/
-Interaction::Interaction()
-{
-    id = -1;
-    is_covered = false;
-    is_detectable = false;
-}
-
-/* CONSTRUCTOR - initializes the object
  * - overloaded: this version can set its fields based on a premade vector of Single pointers
 */
-Interaction::Interaction(std::vector<Single*> *temp) : Interaction::Interaction()
+Interaction::Interaction(std::vector<Single*> *temp)
 {
     for (uint64_t i = 0; i < temp->size(); i++) singles.push_back(temp->at(i));
 }
@@ -65,17 +55,9 @@ std::string Interaction::to_string()
 }
 
 /* CONSTRUCTOR - initializes the object
- * - overloaded: this is the default with no parameters, and should not be used
-*/
-T::T()
-{
-    is_locatable = false;
-}
-
-/* CONSTRUCTOR - initializes the object
  * - overloaded: this version can set its fields based on a premade vector of Interaction pointers
 */
-T::T(std::vector<Interaction*> *temp) : T::T()
+T::T(std::vector<Interaction*> *temp)
 {
     for (uint64_t i = 0; i < temp->size(); i++) interactions.push_back(temp->at(i));
 

--- a/Sources/factor.cpp
+++ b/Sources/factor.cpp
@@ -13,48 +13,28 @@ Last updated 10/04/2022
 #include <algorithm>
 
 /* CONSTRUCTOR - initializes the object
- * - overloaded: this is the default with no parameters, and should not be used
-*/
-Single::Single()
-{
-    c_issues = 0; l_issues = 0; d_issues = 0;   // to be incremented later
-    factor = 0;
-    value = 0;
-}
-
-/* CONSTRUCTOR - initializes the object
  * - overloaded: this version can set its fields based on parameters
 */
-Single::Single(uint64_t f, uint64_t v) : Single::Single()
+Single::Single(uint64_t f, uint64_t v) : factor(f), value(v), str_rep(this->to_string_internal())
 {
-    factor = f;
-    value = v;
     // rows will be built later
 }
 
-std::string Single::to_string()
+std::string Single::to_string() const
+{
+    return str_rep;
+}
+
+std::string Single::to_string_internal() const
 {
     return "f" + std::to_string(factor) + "," + std::to_string(value);
 }
 
 /* CONSTRUCTOR - initializes the object
- * - overloaded: this is the default with no parameters, and should not be used
-*/
-Factor::Factor()
-{
-    c_issues = 0; l_issues = 0; d_issues = 0;   // to be incremented later
-    id = 0;
-    level = 0;
-    singles = nullptr;
-}
-
-/* CONSTRUCTOR - initializes the object
  * - overloaded: this version can set its fields based on parameters
 */
-Factor::Factor(uint64_t i, uint64_t l, Single **ptr_array) : Factor::Factor()
+Factor::Factor(uint64_t i, uint64_t l, Single **ptr_array) : id(i), level(l)
 {
-    id = i;
-    level = l;
     singles = ptr_array;
 }
 

--- a/makefile
+++ b/makefile
@@ -13,7 +13,7 @@ CXXFLAGS += -pedantic -Wall -Wextra -Wcast-align -Wcast-qual -Wctor-dtor-privacy
 
 build: generate
 build-debug: CXXFLAGS += -g -g3
-build-debug: CXXFLAGS:=$(filter-out -O3, $(C++FLAGS))
+build-debug: CXXFLAGS:=$(filter-out -O3, $(CXXFLAGS))
 build-debug: build
 
 generate: $(HDR)/* $(SRC)/*


### PR DESCRIPTION

Make `Single`'s `factor` and `value` members const and make `to_string` just return `str_rep`, a const string member on `Single`.

This PR also fixes a typo in the makefile when removing `-O3` for debug builds.

This change, combined with the enabling optimization level 3, leads to a reduction of runtime by order of magnitude (measured improvement from ~16 seconds to ~1.6 seconds).

I think exploring struct based keys, instead of strings, is the next step for further gains in performance.
Application level tests and a built-in benchmark would also be useful.